### PR TITLE
Fix transpose of psi to conjugate transpose

### DIFF
--- a/python/pure_states_expect.py
+++ b/python/pure_states_expect.py
@@ -6,4 +6,4 @@ cs = np.array([1/np.sqrt(3),1j/np.sqrt(3),-1/np.sqrt(3)]) # some coefficients (n
 psi = sum([c*basis[j] for j,c in enumerate(cs)]) # the state psi
 A = np.array([[1,0,0],[0,2,0],[0,0,3]]) # some operator
 # expectation value of A in state psi
-exp_A = np.real(psi.T @ A @ psi)
+exp_A = np.real(np.conjugate(psi).T @ A @ psi)


### PR DESCRIPTION
I noticed what I think is a mistake in the first example in script 2.1. psi.T only gives the transpose, but not the conjugate transpose.